### PR TITLE
Fix: core VSP processing, SEG-Y I/O scaling, and decon logic

### DIFF
--- a/iovsp/segyin.py
+++ b/iovsp/segyin.py
@@ -138,16 +138,22 @@ def readsegyio3(inputfile, file_headers,ttbyte,ttscalar,DF_ASL, SrcElev, SRD_ASL
         src = np.array(f.attributes(17))
         nsamp = np.array(f.attributes(115))
         srate = np.array(f.attributes(117))
+        def apply_scalar(arr, scalar):
+            # If 0, assume 1. If negative, divide. If positive, multiply.
+            scalar = np.where(scalar == 0, 1, scalar)
+            return np.where(scalar < 0, arr / np.abs(scalar), arr * scalar)
+
         zscale = np.array(f.attributes(69))
-        mdpth = np.array(f.attributes(37)/abs(zscale))
-        tvddpth = np.array(f.attributes(41)/abs(zscale))
-        srd = np.array(f.attributes(53)/abs(zscale))
         scalcoord = np.array(f.attributes(71))
-        xsrc = np.array(f.attributes(73)/abs(scalcoord))
-        ysrc = np.array(f.attributes(77)/abs(scalcoord))
-        sdpth = np.array(f.attributes(49)/abs(zscale))
-        xrcv = np.array(f.attributes(81)/abs(scalcoord))
-        yrcv = np.array(f.attributes(85)/abs(scalcoord))
+
+        mdpth = apply_scalar(np.array(f.attributes(37)), zscale)
+        tvddpth = apply_scalar(np.array(f.attributes(41)), zscale)
+        srd = apply_scalar(np.array(f.attributes(53)), zscale)
+        xsrc = apply_scalar(np.array(f.attributes(73)), scalcoord)
+        ysrc = apply_scalar(np.array(f.attributes(77)), scalcoord)
+        sdpth = apply_scalar(np.array(f.attributes(49)), zscale)
+        xrcv = apply_scalar(np.array(f.attributes(81)), scalcoord)
+        yrcv = apply_scalar(np.array(f.attributes(85)), scalcoord)
     
         lagtime_A  = np.array(f.attributes(105))          #trunc. to nearest ms
         lagtime_B  = np.array(f.attributes(107))            # trunc.to nearest ms
@@ -306,16 +312,20 @@ def readsegy(inputfile, file_headers,DF_ASL, SrcElev, SRD_ASL, PTS):
         src[n] = tr.header.energy_source_point_number
         nsamp[n] = tr.header.number_of_samples_in_this_trace
         srate[n] = tr.header.sample_interval_in_ms_for_this_trace
+        def apply_scalar_single(value, scalar):
+            if scalar == 0: return value
+            return value / abs(scalar) if scalar < 0 else value * scalar
+
         zscale[n] = tr.header.scalar_to_be_applied_to_all_elevations_and_depths
-        mdpth[n] = tr.header.distance_from_center_of_the_source_point_to_the_center_of_the_receiver_group/abs(zscale[n])
-        tvddpth[n] = tr.header.receiver_group_elevation/abs(zscale[n])
-        srd[n] = tr.header.datum_elevation_at_receiver_group/abs(zscale[n])
+        mdpth[n] = apply_scalar_single(tr.header.distance_from_center_of_the_source_point_to_the_center_of_the_receiver_group, zscale[n])
+        tvddpth[n] = apply_scalar_single(tr.header.receiver_group_elevation, zscale[n])
+        srd[n] = apply_scalar_single(tr.header.datum_elevation_at_receiver_group, zscale[n])
         scalcoord[n] = tr.header.scalar_to_be_applied_to_all_coordinates
-        xsrc[n] = tr.header.source_coordinate_x/abs(scalcoord[n])
-        ysrc[n] = tr.header.source_coordinate_y/abs(scalcoord[n])
-        sdpth[n] = tr.header.source_depth_below_surface/abs(zscale[n])
-        xrcv[n] = tr.header.group_coordinate_x/abs(scalcoord[n])
-        yrcv[n] = tr.header.group_coordinate_y/abs(scalcoord[n])
+        xsrc[n] = apply_scalar_single(tr.header.source_coordinate_x, scalcoord[n])
+        ysrc[n] = apply_scalar_single(tr.header.source_coordinate_y, scalcoord[n])
+        sdpth[n] = apply_scalar_single(tr.header.source_depth_below_surface, zscale[n])
+        xrcv[n] = apply_scalar_single(tr.header.group_coordinate_x, scalcoord[n])
+        yrcv[n] = apply_scalar_single(tr.header.group_coordinate_y, scalcoord[n])
         auxtime_ms[n]  = tr.header.lag_time_A          #trunc. to nearest ms
         ttime_ms[n]  = tr.header.lag_time_B            # trunc.to nearest ms
         ttime[n]  = tr.header.shotpoint_number/100     # divide if used

--- a/procvsp/anisomodel.py
+++ b/procvsp/anisomodel.py
@@ -55,12 +55,12 @@ def phase_vel(Vpz,Vsz, epsilon, delta):
     # calculate phase velocities as function of wavefront propagation angle
     for i in range(0,theta.shape[0]):
         phase_velp[i,] = sqrt(.5)*sqrt((Vpx**2*sin(theta[i,])**2+Vpz**2*cos(theta[i,])**2 +Vsz**2)+ 
-        sqrt((( Vpx**2-Vsz**2)*sin(theta[i,])**2 +(Vpz**2-Vsz**2)*cos(theta[i,])**2)**2 +
-        (Vpz**2-Vsz**2)*(Vpn**2-Vpx**2)*(sin(2*theta[i,]))**2))
+        sqrt((( Vpx**2-Vsz**2)*sin(theta[i,])**2 - (Vpz**2-Vsz**2)*cos(theta[i,])**2)**2 +
+        (Vpz**2-Vsz**2)*(Vpn**2-Vsz**2)*(sin(2*theta[i,]))**2))
 
         phase_vels[i,] = sqrt(.5)*sqrt((Vpx**2*sin(theta[i,])**2+Vpz**2*cos(theta[i,])**2 +Vsz**2)-
-        sqrt((( Vpx**2-Vsz**2)*sin(theta[i,])**2 +(Vpz**2-Vsz**2)*cos(theta[i,])**2)**2 +
-        (Vpz**2-Vsz**2)*(Vpn**2-Vpx**2)*(sin(2*theta[i,]))**2))
+        sqrt((( Vpx**2-Vsz**2)*sin(theta[i,])**2 - (Vpz**2-Vsz**2)*cos(theta[i,])**2)**2 +
+        (Vpz**2-Vsz**2)*(Vpn**2-Vsz**2)*(sin(2*theta[i,]))**2))
         
     return phase_velp, phase_vels, theta
 
@@ -374,8 +374,8 @@ def group_vel(Vpz,Vsz, epsilon, delta,dep):
     # group velocity can be calculated from phase velocity and it's components
     for i in range(0,theta.shape[0]):
         term0[i,] = (Vpx**2-Vpz**2)*sin(2*theta[i,])
-        term1[i,] = (Vpx**2-Vs[1,]**2)*sin(theta[i,])**2+(Vpz**2-Vsz**2)*cos(theta[i,])**2        
-        term2[i,] = (Vpz**2-Vsz**2)*(Vpn**2-Vpx**2)
+        term1[i,] = (Vpx**2-Vsz**2)*sin(theta[i,])**2 - (Vpz**2-Vsz**2)*cos(theta[i,])**2        
+        term2[i,] = (Vpz**2-Vsz**2)*(Vpn**2-Vsz**2)
         term3[i,] = term0[i,]+1/(sqrt(term1[i,]**2+term2[i,]*(sin(2*theta[i,])**2)))*\
         (term0[i,]*(Vpx**2-Vpz**2)*sin(2*theta[i,])+term0[i,]*sin(4*theta[i,]))    
 #        term3_a[i,] = 1/(sqrt(term1[i,]**2+term2[i,]*(sin(2*theta[i,])**2)))

--- a/procvsp/decon.py
+++ b/procvsp/decon.py
@@ -555,9 +555,10 @@ def VSP_decon(vspup,vspdown,TTobs_single,stab,samprate,Tmax, Tmin, zrcv_select, 
             U=np.fft.fft(u)
             D=np.fft.fft(d)
             A=np.max(np.absolute(D), axis = 0)
-            Ud=U / (D +(stab*A))
+            # Water-level stabilization
+            Ud = U * np.conjugate(D) / (np.absolute(D)**2 + stab * A**2)
 
-            ud=ifft(Ud)
+            ud=np.real(ifft(Ud))
             vspupd[:,k]=ud
 
 ######## apply a BPF to deconvolved upgoing #########    
@@ -774,6 +775,19 @@ def predict_decon(up_flat,down_flat,theaders_all,**kwargs):
         diff_deconpr=trdsign[0:decon_dwnpr.shape[0],k]-decon_dwnpr
         
         decon_dwn_all[:,k] = decon_dwnpr 
+
+        # Apply filter to upgoing wave 
+        trinpr_up = np.convolve(trin_up[:,k], prfilt, mode='full')
+        trinpr_up = trinpr_up[trim:len(trinpr_up)-trim]
+
+        # Delay and subtract predictable from input upgoing
+        x_up = trin_up[nlag+alignsamp:len(trdsign), k]
+        y_up = trinpr_up[0:len(trdsign)-nlag-alignsamp]
+        PE_up = x_up - y_up
+
+        # Insert the PE into the original trace
+        decon_uppr = np.concatenate((trin_up[0:nlag+alignsamp,k], PE_up[0:len(PE_up)]))
+        decon_up_all[:,k] = decon_uppr
     
     ########## Apply a post-decon band-pass filter ####################
     decon_dwn_filt=np.zeros(shape)    

--- a/procvsp/qtools.py
+++ b/procvsp/qtools.py
@@ -537,7 +537,7 @@ def q_centroid(thead_ref,thead_two,aspec, freq,fs,**kwargs):
     sigtest=np.zeros(shape=Qtest.shape[0])
 
     if(fd1>fd2): 
-        for k in range(0,len(Qtest)-1):
+        for k in range(0,len(Qtest)):  # Removed the -1
             #print (' k :',k,)
             #print (' A1.shape :',A1.shape,' freq.shape : ',freq.shape,' Qtest.shape :',Qtest.shape)
             # test spectrum for different q values            


### PR DESCRIPTION
This PR introduces fixes in geophysical modeling, I/O, and processing modules to ensure mathematical correctness and stability for VSP processing.

## Key Changes:

- **SEG-Y Input (segyin.py)**: Updated zscale and scalcoord application to strictly follow the SEG-Y Rev 1 standard. Scalars greater than 0 are now used as multipliers, while scalars less than 0 are used as divisors.
- **Anisotropy Modeling (anisomodel.py)**: Fixed formulation errors in the exact phase and group velocity calculations for VTI media.
- **Deconvolution (decon.py)**:
  - Corrected the frequency-domain division in VSP_decon to use a mathematically sound water-level stabilization method.
  - Updated predict_decon so that the predictive filter derived from the downgoing wavefield is appropriately applied to the upgoing wavefield, which restores the fundamental multiple-attenuation workflow.
- **Q-Estimation (qtools.py):** Addressed an off-by-one boundary bug during the array iteration for Q-centroid calculations.

These patches stabilize the core processing logic and ensure outputs for AVO modeling and multiple-suppression are geophysically valid.